### PR TITLE
Remove duplicate declarations in old/th_bv.plf

### DIFF
--- a/lfsc/old/th_bv.plf
+++ b/lfsc/old/th_bv.plf
@@ -72,7 +72,6 @@
 
 (declare bvand bvop2)
 (declare bvor bvop2)
-(declare bvor bvop2)
 (declare bvxor bvop2)
 (declare bvnand bvop2)
 (declare bvnor bvop2)
@@ -88,7 +87,6 @@
 (declare bvshl bvop2)
 (declare bvlshr bvop2)
 (declare bvashr bvop2)
-(declare concat bvop2)
 
 ; bit vector unary operators
 (define bvop1


### PR DESCRIPTION
The latest version of LFSC doesn't support them.

Keeping the second declaration is the right thing to do because that's
what LFSC used to use.

This commit is similar to: https://github.com/CVC4/CVC4/pull/5183